### PR TITLE
Manual option

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ ms.use(collect({
     reverse: true
   }
 }))
+
+// pass collections to metalsmith-collections` (for manual collections)
+ms.use(collect({
+  manual: {
+	  navigation: {
+		  sortBy: "ordering"
+	  }
+  }
+}))
 ```
 
  To see the available options, see the [`metalsmith-collections` repo](https://github.com/segmentio/metalsmith-collections).

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ ms.use(collect({
 // pass collections to metalsmith-collections` (for manual collections)
 ms.use(collect({
   manual: {
-	  navigation: {
-		  sortBy: "ordering"
-	  }
+    navigation: {
+      sortBy: "ordering"
+    }
   }
 }))
 ```

--- a/index.js
+++ b/index.js
@@ -12,6 +12,8 @@ const auto_collect = opts => {
   opts.pattern = opts.pattern || '**'
   // get options to pass to metalsmith-collections
   opts.settings = opts.settings || {}
+  // get optional manual collections
+  opts.manual = opts.manual || {}
 
   return (files, metalsmith, done) => {
     setImmediate(done)
@@ -21,10 +23,18 @@ const auto_collect = opts => {
     // when we call metalsmith-collections
     const config = {}
 
+    // Add non-automatic collections to config.
+    Object.keys(opts.manual).forEach(collection => {
+      if (!config[collection]) config[collection] = opts.manual[collection]
+    })
+
     Object.keys(files).forEach(file => {
       if (mm(file, opts.pattern).length) {
         // get name of parent directory
-        let parent = path.dirname(file).split(path.sep).pop()
+        let parent = path
+          .dirname(file)
+          .split(path.sep)
+          .pop()
 
         // set parent to source file in config if file is in root
         parent = parent === '.' ? metalsmith._source : parent

--- a/index.js
+++ b/index.js
@@ -31,10 +31,7 @@ const auto_collect = opts => {
     Object.keys(files).forEach(file => {
       if (mm(file, opts.pattern).length) {
         // get name of parent directory
-        let parent = path
-          .dirname(file)
-          .split(path.sep)
-          .pop()
+        let parent = path.dirname(file).split(path.sep).pop()
 
         // set parent to source file in config if file is in root
         parent = parent === '.' ? metalsmith._source : parent


### PR DESCRIPTION
Hi

I wanted to use automatic collections as well as collections defined by metadata so I added the option to pass manually defined collections to the inner `metalsmith-collections` call. (Because the metadata based collection I was using needed non-default options.)

Cheers,

Wieke